### PR TITLE
feat: add announcement for Fastify in Technology Radar

### DIFF
--- a/linkedin/2-tech-radar.md
+++ b/linkedin/2-tech-radar.md
@@ -1,0 +1,20 @@
+We’re happy to announce that Fastify has been placed in the **Adopt** ring of the Languages & Frameworks section in Thoughtworks’ latest Technology Radar!
+https://www.thoughtworks.com/radar/languages-and-frameworks/fastify
+
+This isn’t just a pat on the back, it’s a powerful validation of what we’ve built together:
+
+* **Performance**: Fastify delivers measurable speed gains over alternatives
+* **Efficiency**: Minimal-overhead core, yet rich functionality: validation, serialization, and parsing
+* **Modularity**: A solid plugin system and strong community support make it highly flexible and extensible
+* **Stability**: According to Thoughtworks, teams "have seen no significant downsides" in using Fastify, making it a compelling choice for web development in Node.js
+
+A huge thank you to:
+
+* Our **core contributors**, plugin authors, and maintainers; your effort underpins this success!
+* The **Fastify community**: every GitHub issue, PR, discussion, and blog post helps push the project forward!
+* The **teams at Thoughtworks and all our users**: your trust in Fastify means the world to us!
+
+This recognition reinforces our commitment to performance, simplicity, and developer experience.
+We’re energized to keep improving and to build the future of web development on Fastify.
+
+Let’s go **faster** ⚡


### PR DESCRIPTION
The link:
https://www.thoughtworks.com/radar/languages-and-frameworks/fastify

Not sure if the formatting is preserved when we post it - is it?
Should we move the link in the first comment? 🤦🏼 